### PR TITLE
Post 엔티티 및 CRUD API 구현 (#11)

### DIFF
--- a/src/main/java/com/workout/api/controller/PostController.java
+++ b/src/main/java/com/workout/api/controller/PostController.java
@@ -1,0 +1,72 @@
+package com.workout.api.controller;
+
+import com.workout.api.dto.PostRequest;
+import com.workout.api.dto.PostResponse;
+import com.workout.api.service.PostService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/posts")
+@RequiredArgsConstructor
+@Tag(name = "Post", description = "게시글 API")
+public class PostController {
+
+    private final PostService postService;
+
+    @PostMapping
+    @Operation(summary = "게시글 생성")
+    public ResponseEntity<PostResponse> create(
+            Authentication authentication,
+            @Valid @RequestBody PostRequest request
+            ) {
+        String email = authentication.getName();
+        PostResponse response = postService.create(email, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "게시글 조회")
+    public ResponseEntity<PostResponse> findById(@PathVariable Long id) {
+        PostResponse response = postService.findById(id);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    @Operation(summary = "게시글 목록 조회")
+    public ResponseEntity<List<PostResponse>> findAll() {
+        List<PostResponse> responses = postService.findAll();
+        return ResponseEntity.ok(responses);
+    }
+
+    @PutMapping("/{id}")
+    @Operation(summary = "게시글 수정")
+    public ResponseEntity<PostResponse> update(
+            @PathVariable Long id,
+            Authentication authentication,
+            @Valid @RequestBody PostRequest request
+    ) {
+        String email = authentication.getName();
+        PostResponse response = postService.update(id, email, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "게시글 삭제")
+    public ResponseEntity<Void> delete(
+            @PathVariable Long id,
+            Authentication authentication
+    ) {
+        String email = authentication.getName();
+        postService.delete(id, email);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/workout/api/dto/PostRequest.java
+++ b/src/main/java/com/workout/api/dto/PostRequest.java
@@ -1,0 +1,18 @@
+package com.workout.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PostRequest {
+
+    @NotBlank(message = "제목은 필수입니다")
+    @Size(max = 200, message = "제목은 200자 이하여야 합니다")
+    private String title;
+
+    @NotBlank(message = "내용은 필수입니다")
+    private String content;
+}

--- a/src/main/java/com/workout/api/dto/PostResponse.java
+++ b/src/main/java/com/workout/api/dto/PostResponse.java
@@ -1,0 +1,32 @@
+package com.workout.api.dto;
+
+import com.workout.api.entity.Post;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class PostResponse {
+
+    private Long id;
+    private String title;
+    private String content;
+    private Long userId;
+    private String userNickName;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static PostResponse from(Post post) {
+        return new PostResponse(
+                post.getId(),
+                post.getTitle(),
+                post.getContent(),
+                post.getUser().getId(),
+                post.getUser().getNickname(),
+                post.getCreatedAt(),
+                post.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/workout/api/entity/Post.java
+++ b/src/main/java/com/workout/api/entity/Post.java
@@ -1,0 +1,47 @@
+package com.workout.api.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "posts")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Post {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/workout/api/repository/PostRepository.java
+++ b/src/main/java/com/workout/api/repository/PostRepository.java
@@ -1,0 +1,9 @@
+package com.workout.api.repository;
+
+import com.workout.api.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+
+}

--- a/src/main/java/com/workout/api/service/PostService.java
+++ b/src/main/java/com/workout/api/service/PostService.java
@@ -1,0 +1,76 @@
+package com.workout.api.service;
+
+import com.workout.api.dto.PostRequest;
+import com.workout.api.dto.PostResponse;
+import com.workout.api.entity.Post;
+import com.workout.api.entity.User;
+import com.workout.api.repository.PostRepository;
+import com.workout.api.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public PostResponse create(String email, PostRequest request) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        Post post = new Post();
+        post.setTitle(request.getTitle());
+        post.setContent(request.getContent());
+        post.setUser(user);
+        Post savedPost = postRepository.save(post);
+
+        return PostResponse.from(savedPost);
+    }
+
+    public PostResponse findById(Long id) {
+        Post post = postRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다"));
+        return PostResponse.from(post);
+    }
+
+    public List<PostResponse> findAll() {
+        return postRepository.findAll().stream()
+                .map(PostResponse::from)
+                .toList();
+    }
+
+    @Transactional
+    public PostResponse update(Long id, String email, PostRequest request) {
+        Post post = postRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다"));
+
+        if (!post.getUser().getEmail().equals(email)) {
+            throw new IllegalArgumentException("본인의 게시글만 수정할 수 있습니다");
+        }
+
+        post.setTitle(request.getTitle());
+        post.setContent(request.getContent());
+
+        return PostResponse.from(post);
+    }
+
+    @Transactional
+    public void delete(Long id, String email) {
+        Post post = postRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다."));
+
+        if (!post.getUser().getEmail().equals(email)) {
+            throw new IllegalArgumentException("본인의 게시글만 삭제할 수 있습니다");
+        }
+
+        postRepository.delete(post);
+
+    }
+}


### PR DESCRIPTION
Post CRUD 기능 구현

- Post 엔티티 생성 (User 연관관계)
- PostRepository, PostService, PostController
- DTO 실무 패턴 적용 (PostRequest)
- Swagger 문서화

Closes #11 